### PR TITLE
Update `Makefile` for recursive mkdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 	glib-compile-schemas --strict --targetdir=schemas/ schemas
 
 install:
-	mkdir ~/.local/share/gnome-shell/extensions/dash2dock-lite@icedman.github.com/
+	mkdir -p ~/.local/share/gnome-shell/extensions/dash2dock-lite@icedman.github.com/
 	cp -R ./* ~/.local/share/gnome-shell/extensions/dash2dock-lite@icedman.github.com/
 
 update:


### PR DESCRIPTION
The `mkdir` command does not work if the `extensions` folder does not exist.

This PR fixes that.