### PR TITLE
Fix issue with desktop icons that is detected as a window

### DIFF
--- a/autohide.js
+++ b/autohide.js
@@ -317,6 +317,7 @@ var AutoHide = class {
     });
     windows = windows.filter((w) => w.can_close());
     windows = windows.filter((w) => w.get_monitor() == monitor.index);
+    windows = windows.filter((w) => w.get_wm_class() != 'com.desktop.ding');
 
     let workspace = global.workspace_manager.get_active_workspace_index();
     windows = windows.filter(


### PR DESCRIPTION
When no windows open, and using desktop icons gnome shell extension 
dash to dock detects it as a window maximized and will be hidden
this patch fixes that issue
