### PR TITLE
Fixes for Gnome 47

### DIFF
--- a/drawing.js
+++ b/drawing.js
@@ -2,7 +2,7 @@
 
 import PangoCairo from 'gi://PangoCairo';
 import Pango from 'gi://Pango';
-import Clutter from 'gi://Clutter';
+import Cogl from 'gi://Cogl';
 
 function draw_rotated_line(ctx, color, width, angle, len, offset) {
   offset = offset || 0;
@@ -114,7 +114,7 @@ function draw_text(ctx, showtext, font = 'DejaVuSans 42') {
 
 function set_color(ctx, clr, alpha) {
   if (typeof clr === 'string') {
-    const [, cc] = Clutter.Color.from_string(clr);
+    const [, cc] = Cogl.Color.from_string(clr);
     ctx.setSourceRGBA(cc.red, cc.green, cc.blue, alpha);
   } else {
     if (clr.red) {

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
     "icedman"
   ],
   "shell-version": [
-    "45", "46"
+    "47"
   ],
   "url": "https://github.com/icedman/dash2dock-lite",
   "uuid": "dash2dock-lite@icedman.github.com",

--- a/tests/drawing.js
+++ b/tests/drawing.js
@@ -1,4 +1,4 @@
-const { Clutter, GObject, GLib, PangoCairo, Pango } = imports.gi;
+const { Cogl, GObject, GLib, PangoCairo, Pango } = imports.gi;
 const Cairo = imports.cairo;
 
 function draw_rotated_line(ctx, color, width, angle, len, offset) {
@@ -111,7 +111,7 @@ function draw_text(ctx, showtext, font = 'DejaVuSans 42') {
 
 function set_color(ctx, clr, alpha) {
   if (typeof clr === 'string') {
-    const [, cc] = Clutter.Color.from_string(clr);
+    const [, cc] = Cogl.Color.from_string(clr);
     ctx.setSourceRGBA(cc.red, cc.green, cc.blue, alpha);
   } else {
     if (clr.red) {


### PR DESCRIPTION
Relatively simple updates for Gnome 47. The only incompatibility I found was the move from `Clutter.Color` to `Cogl.Color`