### PR TITLE
Fixed multi user conflicts in /tmp folder

### DIFF
--- a/dock.js
+++ b/dock.js
@@ -25,6 +25,7 @@ import {
   get_distance,
   isInRect,
   isOverlapRect,
+  tempPath,
 } from './utils.js';
 
 const Point = Graphene.Point;
@@ -333,7 +334,7 @@ export let Dock = GObject.registerClass(
         this.destroyDash();
       }
       let dash = new Dash();
-      dash._adjustIconSize = () => {};
+      dash._adjustIconSize = () => { };
       this.dash = dash;
       this.dash._background.visible = false;
       this.dash._box.clip_to_allocation = false;
@@ -366,7 +367,7 @@ export let Dock = GObject.registerClass(
         'leave-event',
         this._onLeaveEvent.bind(this),
         'destroy',
-        () => {},
+        () => { },
         this,
       );
 
@@ -805,14 +806,14 @@ export let Dock = GObject.registerClass(
           icon: '_downloadsIcon',
           folder: Gio.File.new_for_path('Downloads').get_path(),
           //! find a way to avoid this
-          path: '/tmp/downloads-dash2dock-lite.desktop',
+          path: tempPath('downloads-dash2dock-lite.desktop'),
           show: this.extension.downloads_icon,
           items: '_downloadFiles',
           itemsLength: '_downloadFilesLength',
           prepare: (() => {
             this.extension.services._debounceCheckDownloads();
           }).bind(this),
-          cleanup: () => {},
+          cleanup: () => { },
         },
       ];
 
@@ -835,7 +836,7 @@ export let Dock = GObject.registerClass(
       if (!this._trashIcon && this.extension.trash_icon) {
         // pin trash icon
         //! avoid creating app_info & /tmp/*.desktop files
-        this._trashIcon = this.createItem(`/tmp/trash-dash2dock-lite.desktop`);
+        this._trashIcon = this.createItem(tempPath('trash-dash2dock-lite.desktop'));
         this._icons = null;
       } else if (this._trashIcon && !this.extension.trash_icon) {
         // unpin trash icon

--- a/extension.js
+++ b/extension.js
@@ -27,7 +27,7 @@ import Shell from 'gi://Shell';
 import Graphene from 'gi://Graphene';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
-import { trySpawnCommandLine } from './utils.js';
+import { tempPath, trySpawnCommandLine } from './utils.js';
 
 import { Timer } from './timer.js';
 import { Style } from './style.js';
@@ -42,7 +42,7 @@ import {
 
 import { schemaId, SettingsKeys } from './preferences/keys.js';
 
-const BLURRED_BG_PATH = '/tmp/d2da-bg-blurred.jpg';
+const BLURRED_BG_PATH = tempPath('d2da-bg-blurred.jpg');
 
 const SERVICES_UPDATE_INTERVAL = 2500;
 

--- a/prefs.js
+++ b/prefs.js
@@ -16,6 +16,7 @@ import {
   ExtensionPreferences,
   gettext as _,
 } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { tempPath } from './utils.js';
 
 export default class Preferences extends ExtensionPreferences {
   constructor(metadata) {
@@ -298,7 +299,7 @@ export default class Preferences extends ExtensionPreferences {
         title: 'My Theme',
       };
 
-      let fn = Gio.File.new_for_path(`/tmp/theme.json`);
+      let fn = Gio.File.new_for_path(tempPath('theme.json'));
       let content = JSON.stringify(json, null, 4);
       const [, etag] = fn.replace_contents(
         content,
@@ -309,7 +310,7 @@ export default class Preferences extends ExtensionPreferences {
       );
 
       this.window.add_toast(
-        new Adw.Toast({ title: 'Saved to /tmp/theme.json' }),
+        new Adw.Toast({ title: `Saved to ${tempPath("theme.json")}` }),
       );
 
       this._builder.get_object('theme-export-notice').visible = true;

--- a/services.js
+++ b/services.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import { trySpawnCommandLine } from './utils.js';
+import { tempPath, trySpawnCommandLine } from './utils.js';
 // import { trySpawnCommandLine } from 'resource:///org/gnome/shell/misc/util.js';
 
 import Gio from 'gi://Gio';
@@ -195,7 +195,7 @@ export const Services = class {
   _onMountRemoved(monitor, mount) {
     let basename = mount.get_default_location().get_basename();
     let appname = `mount-${basename}-dash2dock-lite.desktop`;
-    let mount_id = `/tmp/${appname}`;
+    let mount_id = tempPath(appname);
     delete this._mounts[mount_id];
     this.extension.animate();
   }
@@ -209,7 +209,7 @@ export const Services = class {
   setupTrashIcon() {
     let extension_path = this.extension.path;
     let appname = `trash-dash2dock-lite.desktop`;
-    let app_id = `/tmp/${appname}`;
+    let app_id = tempPath(appname);
     let fn = Gio.File.new_for_path(app_id);
     let open_app = 'nautilus --select';
 
@@ -234,7 +234,7 @@ export const Services = class {
     let full_path = Gio.file_new_for_path(path).get_path();
     let extension_path = this.extension.path;
     let appname = `${name}-dash2dock-lite.desktop`;
-    let app_id = `/tmp/${appname}`;
+    let app_id = tempPath(appname);
     let fn = Gio.File.new_for_path(app_id);
     // let open_app = 'xdg-open';
     let open_app = 'nautilus --select';
@@ -277,7 +277,7 @@ export const Services = class {
     let icon = mount.get_icon().names[0] || 'drive-harddisk-solidstate';
     let mount_exec = 'echo "not implemented"';
     let unmount_exec = `umount ${fullpath}`;
-    let mount_id = `/tmp/${appname}`;
+    let mount_id = tempPath(appname);
     let fn = Gio.File.new_for_path(mount_id);
 
     if (!fn.query_exists(null)) {
@@ -558,7 +558,7 @@ export const Services = class {
       console.log(err);
     }
 
-    let fn = Gio.File.new_for_path('/tmp/recents.txt');
+    let fn = Gio.File.new_for_path(tempPath(appname));
     if (fn.query_exists(null)) {
       try {
         const [success, contents] = fn.load_contents(null);

--- a/style.js
+++ b/style.js
@@ -3,12 +3,10 @@
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import St from 'gi://St';
-
-const CustomStylesPath = '/tmp';
+import { tempPath } from './utils';
 
 export const Style = class {
   constructor() {
-    this.uId = GLib.uuid_string_random();
     this.styles = {};
     this.style_contents = {};
   }
@@ -46,7 +44,7 @@ export const Style = class {
     if (fn) {
       theme.unload_stylesheet(fn);
     } else {
-      fn = Gio.File.new_for_path(`${CustomStylesPath}/${name}_${this.uId}.css`);
+      fn = Gio.File.new_for_path(tempPath(`${name}.css`));
       this.styles[name] = fn;
     }
 

--- a/style.js
+++ b/style.js
@@ -3,7 +3,7 @@
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import St from 'gi://St';
-import { tempPath } from './utils';
+import { tempPath } from './utils.js';
 
 export const Style = class {
   constructor() {

--- a/utils.js
+++ b/utils.js
@@ -13,6 +13,18 @@ const pointer_wrapper = {
   },
 };
 
+// Use UUID to avoid conflicting with other instances of this extensions (multi user setup)
+const uuid = GLib.uuid_string_random();
+
+/**
+ * Return a path in /tmp folder with a unique name
+ * @param {*} path 
+ * @returns {string}
+ */
+export const tempPath = (path) => {
+  return `/tmp/${uuid}-${path}`
+};
+
 export const getPointer = () => {
   return pointer_wrapper;
 };


### PR DESCRIPTION
Hey, like i said in #193 in multi user setup, multiples instances are trying to access the same protected files in `/tmp` folder and allow only one instance to be fully working (the first instance to be invoked).

I saw your fix in 1728cf3 using UUID, however some other mentions to `/tmp` was not fixed and after installing the extension from the repo, the error was still here.

So i changed the way to generate `/tmp` paths by using a new `Utils` function, the function simply add a static UUID to the path. I tried my fork in my system and everything was working okay so i  created this PR.