### PR TITLE
Add support for GNOME 49

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ### Notice
 
-* Supports Gnome 42, 43, 44, 45, 46, 47, 49
+* Supports Gnome 42, 43, 44, 45, 46, 47, 48, 49
 * Prior versions are largely unsupported
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ### Notice
 
-* Supports Gnome 42, 43, 44, 45, 46, 47
+* Supports Gnome 42, 43, 44, 45, 46, 47, 49
 * Prior versions are largely unsupported
 
 ### Features

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
     "icedman"
   ],
   "shell-version": [
-    "45", "46", "47", "48"
+    "45", "46", "47", "48", "49"
   ],
   "url": "https://github.com/icedman/dash2dock-lite",
   "uuid": "dash2dock-lite@icedman.github.com",


### PR DESCRIPTION
This PR adds support for GNOME 49 to Dash-to-Dock. The following changes were made:

- Updated metadata.json to include GNOME 49 compatibility.
- Updated the README.md to mention support update.