### PR TITLE
Fix dash bluring only light wallpaper on dual wallpaper setup

### DIFF
--- a/dockItemMenu.js
+++ b/dockItemMenu.js
@@ -153,7 +153,9 @@ export const DockItemList = GObject.registerClass(
           this.visible = false;
           this.dock._maybeBounce(this._target);
 
-          trySpawnCommandLine(cmd);
+          trySpawnCommandLine(cmd).catch((err) => {
+            console.log(err);
+          });
         });
       });
 

--- a/utils.js
+++ b/utils.js
@@ -91,8 +91,9 @@ export const trySpawnCommandLine = function (cmd) {
   return new Promise((resolve, reject) => {
     try {
       GLib.spawn_command_line_async(cmd);
+      resolve();
     } catch (err) {
-      console.log(err);
+      reject(err);
     }
   });
 };


### PR DESCRIPTION
Pre-blur and cache both wallpaper variants and switch them in real time when GNOME’s color scheme flips so the dock blur tracks light/dark wallpapers correctly. Fixes #239