### PR TITLE
Migrate to GNOME 50 and modernize deprecated APIs

### DIFF
--- a/animator.js
+++ b/animator.js
@@ -139,7 +139,13 @@ export let Animator = class {
     }
 
     let m = dock.getMonitor();
-    let pointer = global.get_pointer();
+    let pointer;
+    if (global.display.get_cursor_location) {
+      let rect = global.display.get_cursor_location();
+      pointer = [rect.x, rect.y];
+    } else {
+      pointer = global.get_pointer();
+    }
 
     // simulated or transformed pointers
     if (dock.extension.simulated_pointer) {
@@ -308,18 +314,17 @@ export let Animator = class {
         dx = original_pos[1] - py;
       }
 
-      //! _p replace with a more descriptive variable name
-      icon._p = 0;
+      icon._hoverProgress = 0;
       if (dx * dx < threshold * threshold && nearestIcon) {
         let adx = Math.abs(dx);
-        let p = 1.0 - adx / threshold;
-        // let fp = p * 0.6 * (1 + magnify);
-        icon._p = p;
+        let hoverProgress = 1.0 - adx / threshold;
+        // let fp = hoverProgress * 0.6 * (1 + magnify);
+        icon._hoverProgress = hoverProgress;
 
         // affect scale;
         if (magnify != 0) {
           // scale += fp;
-          scale = scaleAtMax * Ease(p);
+          scale = scaleAtMax * Ease(hoverProgress);
           if (scale < 1) scale = 1;
         }
 
@@ -429,7 +434,7 @@ export let Animator = class {
     }
 
     let lockPosition =
-      didScale && first && last && first._p == 0 && last._p == 0;
+      didScale && first && last && first._hoverProgress == 0 && last._hoverProgress == 0;
 
     if (dock._preview) {
       lockPosition = false;
@@ -442,18 +447,19 @@ export let Animator = class {
 
       icon._scale = icon._targetScale;
 
-      //! make these computation more readable even if more verbose
-      let rdir =
-        dock._position == DockPosition.TOP ||
-        dock._position == DockPosition.LEFT
-          ? 1
-          : -1;
+      const isTopOrLeft =
+        dock._position === DockPosition.TOP ||
+        dock._position === DockPosition.LEFT;
+      const riseDirection = isTopOrLeft ? 1 : -1;
 
-      let translationX = icon._translate;
-      let translationY = icon._translateRise * rdir;
+      let translationX;
+      let translationY;
       if (vertical) {
-        translationX = icon._translateRise * rdir;
+        translationX = icon._translateRise * riseDirection;
         translationY = icon._translate;
+      } else {
+        translationX = icon._translate;
+        translationY = icon._translateRise * riseDirection;
       }
 
       //-------------------
@@ -484,7 +490,7 @@ export let Animator = class {
       }
 
       // fix jitterness
-      if (lockPosition && icon._p == 0) {
+      if (lockPosition && icon._hoverProgress == 0) {
         icon._positionCache = icon._positionCache || [];
         var lockThreshold = 48;
         if (
@@ -611,23 +617,8 @@ export let Animator = class {
           if (icon_name) {
             renderer.icon_name = icon_name;
           } else {
-            //! clone
             if (icon._icon.gicon) {
-              let clone = icon._icon.gicon.file;
-              if (
-                renderer.gicon &&
-                renderer.gicon.file &&
-                renderer.gicon.file.get_path() ==
-                  icon._icon.gicon.file.get_path()
-              ) {
-                clone = false;
-              }
-              if (clone) {
-                renderer.gicon = new Gio.FileIcon({
-                  file: icon._icon.gicon.file,
-                });
-              }
-              // #issue 188
+              // Directly assign the icon's gicon to the renderer (fixed in #issue 188)
               renderer.gicon = icon._icon.gicon;
             }
           }
@@ -793,35 +784,7 @@ export let Animator = class {
           icon._icon == dock._dragged && dock._dragging ? 75 : 255;
       }
 
-      //! make more readable
-      let flags = {
-        bottom: {
-          x: 0.5,
-          y: 1,
-          lx: 0,
-          ly: 0.5 * icon._targetScale * scaleFactor,
-        },
-        top: {
-          x: 0.5,
-          y: 0,
-          lx: 0,
-          ly: -1.5 * icon._targetScale * scaleFactor,
-        },
-        left: {
-          x: 0,
-          y: 0.5,
-          lx: -1.25 * icon._targetScale * scaleFactor,
-          ly: -1.25,
-        },
-        right: {
-          x: 1,
-          y: 0.5,
-          lx: 1.5 * icon._targetScale * scaleFactor,
-          ly: -1.25,
-        },
-      };
 
-      let posFlags = flags[dock._position];
 
       // badges
       //! ***badge location at scaling is messed up***
@@ -911,13 +874,13 @@ export let Animator = class {
         actor.translationY =
           (prev._icon.translationY + next._icon.translationY) / 2;
         let thickness = dock.extension.separator_thickness || 0;
-        //! use ifs for more readability
-        actor.width = !vertical
-          ? thickness + 0.5
-          : iconSize * 0.5 * scaleFactor;
-        actor.height = vertical
-          ? thickness + 0.5
-          : iconSize * 0.75 * scaleFactor;
+        if (vertical) {
+          actor.width = iconSize * 0.5 * scaleFactor;
+          actor.height = thickness + 0.5;
+        } else {
+          actor.width = thickness + 0.5;
+          actor.height = iconSize * 0.75 * scaleFactor;
+        }
         actor.visible = thickness > 0;
       }
 
@@ -937,8 +900,7 @@ export let Animator = class {
       }
     }
 
-    //! use a more descriptive variable name
-    let ed =
+    const edgeDirectionMultiplier =
       dock._position == DockPosition.BOTTOM ||
       dock._position == DockPosition.RIGHT
         ? 1
@@ -955,26 +917,28 @@ export let Animator = class {
       if (vertical) {
         if (dock._position == DockPosition.LEFT) {
           targetX =
-            -(dock._background.width + edge_distance * -ed * 2) * scaleFactor;
+            -(dock._background.width + edge_distance * -edgeDirectionMultiplier * 2) * scaleFactor;
         } else {
           targetX =
-            (dock._background.width - edge_distance * -ed * 2) * scaleFactor;
+            (dock._background.width - edge_distance * -edgeDirectionMultiplier * 2) * scaleFactor;
         }
       } else {
         if (dock._position == DockPosition.BOTTOM) {
           targetY =
-            (dock._background.height - edge_distance * -ed * 2) * scaleFactor;
+            (dock._background.height - edge_distance * -edgeDirectionMultiplier * 2) * scaleFactor;
         } else {
           targetY =
-            -(dock._background.height + edge_distance * -ed * 2) * scaleFactor;
+            -(dock._background.height + edge_distance * -edgeDirectionMultiplier * 2) * scaleFactor;
         }
       }
     }
 
     // edge
-    //! use ifs for more readability
-    targetX += vertical ? edge_distance * -ed : 0;
-    targetY += !vertical ? edge_distance * -ed : 0;
+    if (vertical) {
+      targetX += edge_distance * -edgeDirectionMultiplier;
+    } else {
+      targetY += edge_distance * -edgeDirectionMultiplier;
+    }
 
     // dock translation
     {

--- a/autohide.js
+++ b/autohide.js
@@ -1,8 +1,18 @@
 'use strict';
 
 import Meta from 'gi://Meta';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 
 import { DockPosition } from './dock.js';
+
+const GNOME_VERSION = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
+
+function getWindowActors() {
+  if (GNOME_VERSION >= 48) {
+    return Meta.Compositor.get_window_actors(global.display);
+  }
+  return getWindowActors();
+}
 import {
   get_distance_sqr,
   get_distance,
@@ -45,7 +55,7 @@ export let AutoHide = class {
 
     this._enabled = false;
 
-    let actors = global.get_window_actors();
+    let actors = getWindowActors();
     let windows = actors.map((a) => a.get_meta_window());
     windows.forEach((w) => {
       if (w._tracked) {
@@ -65,7 +75,13 @@ export let AutoHide = class {
   _onMotionEvent() {
     if (this.extension.pressure_sense && !this._shown) {
       let monitor = this.dock._monitor;
-      let pointer = global.get_pointer();
+      let pointer;
+      if (global.display.get_cursor_location) {
+        let rect = global.display.get_cursor_location();
+        pointer = [rect.x, rect.y];
+      } else {
+        pointer = global.get_pointer();
+      }
       if (this.extension.simulated_pointer) {
         pointer = [...this.extension.simulated_pointer];
       }
@@ -195,7 +211,13 @@ export let AutoHide = class {
     if (this.extension._inOverview) {
       return false;
     }
-    let pointer = global.get_pointer();
+    let pointer;
+    if (global.display.get_cursor_location) {
+      let rect = global.display.get_cursor_location();
+      pointer = [rect.x, rect.y];
+    } else {
+      pointer = global.get_pointer();
+    }
     if (this.extension.simulated_pointer) {
       pointer = [...this.extension.simulated_pointer];
     }
@@ -237,7 +259,7 @@ export let AutoHide = class {
     // console.log("checking windows...");
 
     let monitor = this.dock._monitor;
-    let actors = global.get_window_actors();
+    let actors = getWindowActors();
     let windows = actors.map((a) => {
       let w = a.get_meta_window();
       w._parent = a;

--- a/dock.js
+++ b/dock.js
@@ -29,6 +29,7 @@ import {
 } from './utils.js';
 
 const Point = Graphene.Point;
+const GNOME_VERSION = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
 
 export const DockPosition = {
   BOTTOM: 'bottom',
@@ -205,6 +206,7 @@ export let Dock = GObject.registerClass(
     }
 
     _onButtonPressEvent(evt) {
+      this._lastButtonEvent = evt;
       return Clutter.EVENT_PROPAGATE;
     }
 
@@ -428,7 +430,7 @@ export let Dock = GObject.registerClass(
 
       Main.layoutManager.addChrome(this.struts, {
         affectsStruts: !this.extension.autohide_dash,
-        ...(Config.PACKAGE_VERSION[0] == '4'
+        ...(GNOME_VERSION < 50
           ? { affectsInputRegion: true }
           : {}),
         trackFullscreen: false,
@@ -1370,9 +1372,9 @@ export let Dock = GObject.registerClass(
         return;
       }
 
-      let event = Clutter.get_current_event();
-      let modifiers = event ? event.get_state() : 0;
-      let pressed = event.type() == Clutter.EventType.BUTTON_PRESS;
+      let event = this._lastButtonEvent;
+      let modifiers = event ? event.get_modifier_state() : 0;
+      let pressed = event ? event.get_event_type() == Clutter.EventType.BUTTON_PRESS : true;
       let button1 = (modifiers & Clutter.ModifierType.BUTTON1_MASK) != 0;
       let button2 = (modifiers & Clutter.ModifierType.BUTTON2_MASK) != 0;
       let button3 = (modifiers & Clutter.ModifierType.BUTTON3_MASK) != 0;
@@ -1514,7 +1516,13 @@ export let Dock = GObject.registerClass(
 
     _onScrollEvent(obj, evt) {
       this._lastScrollEvent = evt;
-      let pointer = global.get_pointer();
+      let pointer;
+      if (global.display.get_cursor_location) {
+        let rect = global.display.get_cursor_location();
+        pointer = [rect.x, rect.y];
+      } else {
+        pointer = global.get_pointer();
+      }
       let target = this._nearestIcon; // this._hoveredIcon;
       // console.log(`${target == this._hoveredIcon}`);
       if (target) {
@@ -1525,9 +1533,10 @@ export let Dock = GObject.registerClass(
 
         // adjustment for touch scroll (much more sensitive) and mouse scrollwheel
         let multiplier = 1;
+        let device = evt.get_source_device();
         if (
-          evt.get_source_device().get_device_type() == 5 ||
-          evt.get_source_device().get_device_name().includes('Touch')
+          device.get_device_type() == Clutter.InputDeviceType.TOUCHSCREEN_DEVICE ||
+          device.get_device_name().includes('Touch')
         ) {
           multiplier = 1;
         } else {
@@ -1542,15 +1551,20 @@ export let Dock = GObject.registerClass(
         if (icon._appwell && icon._appwell.app) {
           this._lastScrollObject = icon;
           let direction = evt.get_scroll_direction();
-          switch (direction) {
-            case Clutter.ScrollDirection.UP:
-            case Clutter.ScrollDirection.LEFT:
-              this._scrollCounter += (1 / SCROLL_RESOLUTION) * multiplier;
-              break;
-            case Clutter.ScrollDirection.DOWN:
-            case Clutter.ScrollDirection.RIGHT:
-              this._scrollCounter -= (1 / SCROLL_RESOLUTION) * multiplier;
-              break;
+          if (direction === Clutter.ScrollDirection.SMOOTH) {
+            let [, dy] = evt.get_scroll_delta();
+            this._scrollCounter += dy * (1 / SCROLL_RESOLUTION) * multiplier * -1;
+          } else {
+            switch (direction) {
+              case Clutter.ScrollDirection.UP:
+              case Clutter.ScrollDirection.LEFT:
+                this._scrollCounter += (1 / SCROLL_RESOLUTION) * multiplier;
+                break;
+              case Clutter.ScrollDirection.DOWN:
+              case Clutter.ScrollDirection.RIGHT:
+                this._scrollCounter -= (1 / SCROLL_RESOLUTION) * multiplier;
+                break;
+            }
           }
           this._cycleWindows(icon._appwell.app, evt);
         }

--- a/drawing.js
+++ b/drawing.js
@@ -115,9 +115,37 @@ function draw_text(ctx, showtext, font = 'DejaVuSans 42') {
 
 function set_color(ctx, clr, alpha) {
   if (typeof clr === 'string') {
-    const fn = Cogl?.Color.from_string || Clutter?.Color.from_string;
-    const [, cc] = fn(clr);
-    ctx.setSourceRGBA(cc.red, cc.green, cc.blue, alpha);
+    try {
+      const fn = Cogl?.Color.from_string || Clutter?.Color.from_string;
+      if (fn) {
+        const [, cc] = fn(clr);
+        ctx.setSourceRGBA(cc.red, cc.green, cc.blue, alpha);
+        return;
+      }
+    } catch (e) {
+      // fallback to manual parsing
+    }
+    let r = 0, g = 0, b = 0;
+    if (clr.startsWith('#')) {
+      let hex = clr.slice(1);
+      if (hex.length === 3) {
+        r = parseInt(hex[0] + hex[0], 16) / 255;
+        g = parseInt(hex[1] + hex[1], 16) / 255;
+        b = parseInt(hex[2] + hex[2], 16) / 255;
+      } else if (hex.length >= 6) {
+        r = parseInt(hex.slice(0, 2), 16) / 255;
+        g = parseInt(hex.slice(2, 4), 16) / 255;
+        b = parseInt(hex.slice(4, 6), 16) / 255;
+      }
+    } else if (clr.startsWith('rgb')) {
+      let match = clr.match(/\d+/g);
+      if (match && match.length >= 3) {
+        r = parseInt(match[0]) / 255;
+        g = parseInt(match[1]) / 255;
+        b = parseInt(match[2]) / 255;
+      }
+    }
+    ctx.setSourceRGBA(r, g, b, alpha);
   } else {
     if (clr.red) {
       ctx.setSourceRGBA(clr.red, clr.green, clr.blue, alpha);

--- a/effects/blur_effect.js
+++ b/effects/blur_effect.js
@@ -2,6 +2,7 @@
 
 import Shell from 'gi://Shell';
 import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
 
@@ -13,7 +14,10 @@ const getBlurShaderSource = (extensionDir) => {
   ]);
 
   try {
-    return Shell.get_file_contents_utf8_sync(SHADER_PATH);
+    const file = Gio.File.new_for_path(SHADER_PATH);
+    const [ok, contents] = file.load_contents(null);
+    if (!ok) return null;
+    return new TextDecoder().decode(contents);
   } catch (e) {
     log(`[d2dl] error loading shader from ${SHADER_PATH}: ${e}`);
     return null;
@@ -44,11 +48,12 @@ export const BlurEffect = GObject.registerClass(
     }
 
     preload(path) {
-      // set shader source
       this._source = getBlurShaderSource(path);
-      if (this._source) this.set_shader_source(this._source);
-
       this.update_enabled();
+    }
+
+    vfunc_get_static_shader_source() {
+      return this._source;
     }
 
     get red() {

--- a/effects/color_effect.js
+++ b/effects/color_effect.js
@@ -4,6 +4,7 @@
 
 import Shell from 'gi://Shell';
 import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
 
@@ -15,7 +16,10 @@ const getColorEffectShaderSource = (extensionDir) => {
   ]);
 
   try {
-    return Shell.get_file_contents_utf8_sync(SHADER_PATH);
+    const file = Gio.File.new_for_path(SHADER_PATH);
+    const [ok, contents] = file.load_contents(null);
+    if (!ok) return null;
+    return new TextDecoder().decode(contents);
   } catch (e) {
     log(`[d2dl] error loading shader from ${SHADER_PATH}: ${e}`);
     return null;
@@ -54,11 +58,12 @@ export const ColorEffect = GObject.registerClass(
     }
 
     preload(path) {
-      // set shader source
       this._source = getColorEffectShaderSource(path);
-      if (this._source) this.set_shader_source(this._source);
-
       this.update_enabled();
+    }
+
+    vfunc_get_static_shader_source() {
+      return this._source;
     }
 
     get red() {

--- a/effects/monochrome_effect.js
+++ b/effects/monochrome_effect.js
@@ -5,6 +5,7 @@
 
 import Shell from 'gi://Shell';
 import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
 
@@ -16,7 +17,10 @@ const getMonochromeShaderSource = (extensionDir) => {
   ]);
 
   try {
-    return Shell.get_file_contents_utf8_sync(SHADER_PATH);
+    const file = Gio.File.new_for_path(SHADER_PATH);
+    const [ok, contents] = file.load_contents(null);
+    if (!ok) return null;
+    return new TextDecoder().decode(contents);
   } catch (e) {
     log(`[d2dl] error loading shader from ${SHADER_PATH}: ${e}`);
     return null;
@@ -55,11 +59,12 @@ export const MonochromeEffect = GObject.registerClass(
     }
 
     preload(path) {
-      // set shader source
       this._source = getMonochromeShaderSource(path);
-      if (this._source) this.set_shader_source(this._source);
-
       this.update_enabled();
+    }
+
+    vfunc_get_static_shader_source() {
+      return this._source;
     }
 
     get red() {

--- a/effects/tint_effect.js
+++ b/effects/tint_effect.js
@@ -4,6 +4,7 @@
 
 import Shell from 'gi://Shell';
 import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
 
@@ -15,7 +16,10 @@ const getTintShaderSource = (extensionDir) => {
   ]);
 
   try {
-    return Shell.get_file_contents_utf8_sync(SHADER_PATH);
+    const file = Gio.File.new_for_path(SHADER_PATH);
+    const [ok, contents] = file.load_contents(null);
+    if (!ok) return null;
+    return new TextDecoder().decode(contents);
   } catch (e) {
     log(`[d2dl] error loading shader from ${SHADER_PATH}: ${e}`);
     return null;
@@ -55,11 +59,12 @@ export const TintEffect = GObject.registerClass(
     }
 
     preload(path) {
-      // set shader source
       this._source = getTintShaderSource(path);
-      if (this._source) this.set_shader_source(this._source);
-
       this.update_enabled();
+    }
+
+    vfunc_get_static_shader_source() {
+      return this._source;
     }
 
     get red() {

--- a/extension.js
+++ b/extension.js
@@ -207,7 +207,7 @@ export default class Dash2DockLiteExt extends Extension {
     this._showMainOverviewDash(false);
     this.docks = [];
 
-    this.icon_theme = St.IconTheme.new();
+    this.icon_theme = St.IconTheme.get_default();
 
     // integrations
     this.integrations = new Integrations();
@@ -472,7 +472,7 @@ export default class Dash2DockLiteExt extends Extension {
         case 'msg-to-ext': {
           if (value.length) {
             try {
-              eval(value);
+              this._handleExtMessage(value);
             } catch (err) {
               console.log(err);
             }
@@ -828,7 +828,7 @@ export default class Dash2DockLiteExt extends Extension {
       this.services.disable();
       this.services.enable();
     }
-    this._iconTheme = St.IconTheme.new();
+    this._iconTheme = St.IconTheme.get_default();
     this._updateStyle();
     this.recreateAllDocks();
   }
@@ -1187,6 +1187,21 @@ export default class Dash2DockLiteExt extends Extension {
 
     if (this.animate_icons && !disable) {
       this.animate();
+    }
+  }
+
+  _handleExtMessage(value) {
+    const cmd = value.replace(/^this\./, '').replace(/\(\)$/, '');
+    const commands = {
+      'runDiagnostics': () => this.runDiagnostics(),
+      'dumpTimers': () => this.dumpTimers(),
+      'recreateAllDocks': () => this.recreateAllDocks(),
+      'checkHide': () => this.checkHide(),
+    };
+    if (commands[cmd]) {
+      commands[cmd]();
+    } else {
+      console.log(`[d2dl] unhandled msg-to-ext command: ${value}`);
     }
   }
 

--- a/services.js
+++ b/services.js
@@ -333,7 +333,11 @@ export const Services = class {
 
     sources.forEach((source) => {
       let appId = null;
-      if (source.app) {
+      if (source.get_app) {
+        let app = source.get_app();
+        if (app) appId = app.get_id();
+      }
+      if (!appId && source.app) {
         appId = source.app.get_id();
       }
       if (!appId && source._app) {
@@ -357,7 +361,7 @@ export const Services = class {
           source: source,
         };
       }
-      this._appNotices[appId].count = source.count;
+      this._appNotices[appId].count = source.count ?? source.get_count?.() ?? 0;
       this._appNotices[`${appId}`] = this._appNotices[appId];
       if (!appId.endsWith('desktop')) {
         this._appNotices[`${appId}.desktop`] = this._appNotices[appId];

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,14 @@ import Gio from 'gi://Gio';
 
 const pointer_wrapper = {
   get_position: () => {
-    let [px, py] = global.get_pointer();
+    let px, py;
+    if (global.display.get_cursor_location) {
+      let rect = global.display.get_cursor_location();
+      px = rect.x;
+      py = rect.y;
+    } else {
+      [px, py] = global.get_pointer();
+    }
     return [{}, px, py];
   },
   warp: (screen, x, y) => {
@@ -90,7 +97,16 @@ export const isInRect = (r, p, pad) => {
 export const trySpawnCommandLine = function (cmd) {
   return new Promise((resolve, reject) => {
     try {
-      GLib.spawn_command_line_async(cmd);
+      let [ok, argv] = GLib.shell_parse_argv(cmd);
+      if (!ok) {
+        reject(new Error('Failed to parse command'));
+        return;
+      }
+      let proc = new Gio.Subprocess({
+        argv: argv,
+        flags: Gio.SubprocessFlags.NONE,
+      });
+      proc.init(null);
       resolve();
     } catch (err) {
       reject(err);


### PR DESCRIPTION
## Summary

- Replace all deprecated/removed GNOME Shell APIs with modern equivalents while maintaining backward compatibility with GNOME 45-49
- Key migrations: `global.get_pointer()` → `get_cursor_location()`, `global.get_window_actors()` → `Meta.Compositor.get_window_actors()`, `Clutter.get_current_event()` → stored button event, `GLib.spawn_command_line_async()` → `Gio.Subprocess`, `Shell.get_file_contents_utf8_sync()` → `Gio.File.load_contents()`, `set_shader_source()` → `vfunc_get_static_shader_source()`
- Add smooth scroll support for trackpad, improve color parsing resilience, harden MessageTray API
- Replace `eval()` with safe command dispatch in msg-to-ext handler
- Improve version check from string comparison to numeric

## Test plan

- [ ] Reload GNOME Shell and verify no deprecation warnings in `journalctl`
- [ ] Test icon click, Ctrl+click (new window), Shift+click (minimize/maximize), middle-click
- [ ] Test scroll wheel and trackpad scroll on dock
- [ ] Test autohide with window overlap
- [ ] Test icon effects (tint/monochrome)
- [ ] Test notification badges
- [ ] Verify backward compatibility on GNOME 45-49

🤖 Generated with [Claude Code](https://claude.com/claude-code)